### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sentencepiece==0.1.97
 datasets==2.4.0
 sacrebleu==2.2.1
-evaluate==0.2.2
+evaluate==0.3.0
 accelerate==0.12.0
 deepspeed==0.7.3
 pandas


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.